### PR TITLE
poprawilem funkcje capitalize

### DIFF
--- a/src/main/java/pl/put/poznan/transformer/logic/TextTransformer.java
+++ b/src/main/java/pl/put/poznan/transformer/logic/TextTransformer.java
@@ -75,7 +75,7 @@ public class TextTransformer {
             if (!w.isEmpty()) {
                 sb.append(Character.toUpperCase(w.charAt(0)));
                 if (w.length()>1) {
-                    sb.append(w.substring(1).toLowerCase());
+                    sb.append(w.substring(1));
                 }
                 sb.append(" ");
             }


### PR DESCRIPTION
Wydaje mi się, że zgodnie z wymaganiami nie ma potrzeby zamiany wielkich liter w środku słów na małe. Fix głównie po to aby przechodziły testy jednostkowe które są wymagane do builda w continuous integration